### PR TITLE
fix: restore Bazel proto_library rules broken by Bzlmod migration

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -1,5 +1,5 @@
-load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 
 package(
     default_visibility = [

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,3 +1,6 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+
 package(
     default_visibility = [
         "//src:__subpackages__",

--- a/src/quipper/BUILD
+++ b/src/quipper/BUILD
@@ -1,5 +1,5 @@
-load("@protobuf//bazel:proto_library.bzl", "proto_library")
-load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 
 licenses(["notice"])
 

--- a/src/quipper/BUILD
+++ b/src/quipper/BUILD
@@ -1,3 +1,5 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 
 licenses(["notice"])
 


### PR DESCRIPTION
## Summary

After a dormant period, CI began failing on both `build-and-test` and `test-deb-build` jobs with:

```
ERROR: name 'proto_library' is not defined
ERROR: name 'cc_proto_library' is not defined
ERROR: package contains errors: src/quipper
```

**Root cause**: Under Bzlmod, `proto_library` and `cc_proto_library` are no longer globally available as native rules. They must be explicitly loaded from the `@protobuf` module (protobuf 21+/Bzlmod requirement). Both `src/quipper/BUILD` and `src/BUILD` were using these rules without the required `load(...)` statements.

## Changes

Added the following two load statements at the top of both `src/quipper/BUILD` and `src/BUILD`:

```python
load("@protobuf//bazel:proto_library.bzl", "proto_library")
load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
```

The `MODULE.bazel` already correctly declares `protobuf` as a `bazel_dep` (version `31.1`) — no changes needed there. Only the BUILD file load statements were missing.

## Test plan

- [ ] `build-and-test` CI job passes (bazel build + test on `//src:all //src/quipper:all`)
- [ ] `test-deb-build` CI job passes (the deb build script calls bazel under the hood)