### PR TITLE
chore: bump GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/apt-release.yml
+++ b/.github/workflows/apt-release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -52,7 +52,7 @@ jobs:
           FPM_SKIP_INSTALL=1 ./scripts/build-deb.sh ${{ steps.release_tag.outputs.tag }}
 
       - name: Upload .deb artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deb-package
           path: artifacts/*.deb
@@ -65,7 +65,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
           sudo apt-get install -y reprepro
 
       - name: Download .deb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: deb-package
           path: ./artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -90,7 +90,7 @@ jobs:
           which perf_to_profile || echo "Binary not in PATH (expected)"
 
       - name: Upload test .deb artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-deb-package
           path: artifacts/*.deb
@@ -101,7 +101,7 @@ jobs:
     needs: test-deb-build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install reprepro
         run: |
@@ -109,7 +109,7 @@ jobs:
           sudo apt-get install -y reprepro
 
       - name: Download test .deb package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: test-deb-package
           path: ./test-artifacts


### PR DESCRIPTION
GitHub is deprecating the **node20** runner for GitHub Actions on **June 16, 2026**. Workflow steps using node20-based action versions will fail after this date.

This PR bumps all affected actions to their latest node24-compatible versions.

> Reviewed by 3 independent agents (opus/sonnet/haiku) before opening.